### PR TITLE
fix: fix owasp site markdown table render

### DIFF
--- a/info.md
+++ b/info.md
@@ -1,12 +1,11 @@
 ### Social Media
 
-* [Google Group | toronto-chapter@owasp.org](https://groups.google.com/a/owasp.org/forum/#!forum/toronto-chapter)
+* [Google Group toronto-chapter@owasp.org](https://groups.google.com/a/owasp.org/forum/#!forum/toronto-chapter)
 
-* [Slack #owasp-toronto-chapter](https://owasp.slack.com/archives/C075DRCB1PZ)
-  * You do not need an OWASP account to signup to the workspace.
+* [Slack #owasp-toronto-chapter](https://owasp.slack.com/archives/C075DRCB1PZ) (you do not need an OWASP account to signup to the workspace)
 
-* [Meetup.com | OWASP Toronto Chapter](https://www.meetup.com/OWASP-Toronto/)
+* [Meetup.com OWASP Toronto Chapter](https://www.meetup.com/OWASP-Toronto/)
 
-* [YouTube | @owasptoronto7639](https://www.youtube.com/channel/UCqmBl-u_4cOEiH3OXWE3sPg)
+* [YouTube @owasptoronto7639](https://www.youtube.com/channel/UCqmBl-u_4cOEiH3OXWE3sPg)
 
-* [Twitter | @OWASPToronto](https://twitter.com/OWASPToronto)
+* [Twitter @OWASPToronto](https://twitter.com/OWASPToronto)

--- a/leaders.md
+++ b/leaders.md
@@ -4,5 +4,5 @@
 * [Yuk Fai Chan](mailto:yukfai.chan@owasp.org)
 * [Adam Greenhill](mailto:adam.greenhill@owasp.org)
 * [Jack Enders](mailto:jack.enders@owasp.org)
-* [Ads Dawson](mailto:ads.dawson@owasp.org) | [LinkedIn](https://linkedin.com/in/adamdawson0) | [GitHub](https://github.com/GangGreenTemperTatum)
+* [Ads Dawson](mailto:ads.dawson@owasp.org), [LinkedIn](https://linkedin.com/in/adamdawson0), [GitHub](https://github.com/GangGreenTemperTatum)
 * [Ignatius Michael](#)


### PR DESCRIPTION
fixes https://github.com/OWASP/www-chapter-toronto/pull/1

![image](https://github.com/OWASP/www-chapter-toronto/assets/104169244/d77e3017-9438-4554-951e-40ae639241ae)

based on the build code for the site, seems the `|` isn't being escaped and treated as markdown tables, rather than a string